### PR TITLE
Add duplicate vote prevention to governance contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ A decentralized insurance protocol for streaming income built on Stacks.
 SafeStream allows users to protect their streaming income by creating insurance pools. Users can:
 - Create insurance pools with customized parameters
 - Join existing pools as insurers by staking STX
-- Submit claims when they experience income loss
+- Submit claims when they experience income loss 
 - Vote on claims as pool participants
 
 ## Contracts
 - `safe-stream.clar`: Main protocol contract handling pools and claims
-- `governance.clar`: Handles voting and claim approvals
+- `governance.clar`: Handles voting and claim approvals, with duplicate vote prevention
 - `staking.clar`: Manages staking and rewards for insurers
 
 ## Usage
 [Documentation on contract usage and examples]
+
+## Recent Updates
+- Added prevention of duplicate votes on claims to ensure voting integrity
+- Each user can only vote once per claim
+- Attempts to vote multiple times will return error 404

--- a/contracts/governance.clar
+++ b/contracts/governance.clar
@@ -3,6 +3,7 @@
 ;; Constants
 (define-constant min-votes u3)
 (define-constant vote-period u144) ;; ~1 day in blocks
+(define-constant err-already-voted (err u404))
 
 ;; Maps
 (define-map votes
@@ -26,6 +27,7 @@
     (map-get? vote-counts { claim-id: claim-id }))))
     
     (asserts! (< block-height (get end-block vote-count)) (err u403))
+    (asserts! (is-none (map-get? votes { claim-id: claim-id, voter: tx-sender })) err-already-voted)
     
     (map-set votes
       { claim-id: claim-id, voter: tx-sender }

--- a/tests/governance_test.ts
+++ b/tests/governance_test.ts
@@ -1,0 +1,29 @@
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+    name: "Ensure users cannot vote twice on same claim",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get("deployer")!;
+        
+        let block = chain.mineBlock([
+            Tx.contractCall(
+              "governance",
+              "vote-on-claim",
+              [types.uint(1), types.bool(true)],
+              deployer.address
+            )
+        ]);
+        assertEquals(block.receipts[0].result, '(ok true)');
+        
+        block = chain.mineBlock([
+            Tx.contractCall(
+              "governance",
+              "vote-on-claim", 
+              [types.uint(1), types.bool(true)],
+              deployer.address
+            )
+        ]);
+        assertEquals(block.receipts[0].result, '(err u404)');
+    },
+});


### PR DESCRIPTION
This PR adds protection against duplicate voting in the governance contract.

Changes made:
- Added validation to check if user has already voted on a claim
- Added new error constant for duplicate votes (404)
- Added test case to verify duplicate vote prevention
- Updated README with new functionality details

Impact:
- Prevents vote manipulation through duplicate voting
- Maintains voting integrity for claim approvals
- No breaking changes to existing functionality

Testing:
- Added new test case specifically for duplicate vote prevention
- Existing tests continue to pass
- Manually tested with multiple vote scenarios